### PR TITLE
Update translation files

### DIFF
--- a/lib/l10n/app_fi.arb
+++ b/lib/l10n/app_fi.arb
@@ -75,8 +75,6 @@
   "@processing": {},
   "search": "Löydä kanavia",
   "@search": {},
-  "manageYourData": "Hallitse kaikkia tietojasi yhdessä paikassa",
-  "@manageYourData": {},
   "recentChats": "UUSIMMAT KESKUSTELUT",
   "@recentChats": {},
   "channelNameAndIconSuggestion": "Anna kanavalle nimi ja valinnaisesti kuvake",


### PR DESCRIPTION
Updated by "Cleanup translation files" hook in Weblate.

Translation: Linagora/Twake Mobile
Translate-URL: https://hosted.weblate.org/projects/linagora/twake-mobile/